### PR TITLE
varInspector: correct indentation

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/var_list.py
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/var_list.py
@@ -43,8 +43,8 @@ def _getcontentof(x):
         if hasattr(x, '__len__'):
             if len(x) > length:
                 content = str(x[:length])
-        else:
-            content = str(x)
+            else:
+                content = str(x)
         if len(content) > 150:
             return content[:150] + " ..."
     return content


### PR DESCRIPTION
Small error in the indentation caused "UnboundLocalError: local variable 'content' referenced before assignment" in some cases. This will most probably close e.g. https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1344